### PR TITLE
fix mobile menu closing

### DIFF
--- a/src/components/nav/Navbar.svelte
+++ b/src/components/nav/Navbar.svelte
@@ -20,7 +20,7 @@
 
             function handleScroll() {
                 const currentScrollY = window.scrollY;
-                hideNav = currentScrollY > lastScrollY && currentScrollY > 50;
+                hideNav = !$showMobileMenu && currentScrollY > lastScrollY && currentScrollY > 50;
                 lastScrollY = currentScrollY;
             }
 


### PR DESCRIPTION
mobile menu shouldn't close on scroll down of page if it's open

<!--
Thank you for your Pull Request. Please provide a short description of your changes above.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/ScuffleCloud/.github/blob/main/CONTRIBUTING.md
-->
