### PR TITLE
Reduce placeholder email font weight from 500 to 400

### DIFF
--- a/src/components/homepage/EmailForm.svelte
+++ b/src/components/homepage/EmailForm.svelte
@@ -192,7 +192,7 @@
 
                     &::placeholder {
                         color: var(--color-brown600);
-                        font-weight: 500;
+                        font-weight: 400;
                         line-height: 1rem;
                     }
                 }


### PR DESCRIPTION
Changes the font weight from 500 to 400 for the email font weight.

<details>
<summary> font weight 500 </summary>

![image](https://github.com/user-attachments/assets/2e0be8f7-bf92-466c-948b-98166f1dde74)
</details>

<details>
<summary> font weight 400 </summary>

![image](https://github.com/user-attachments/assets/f579bd9e-35c4-47f6-b6af-00dc72f1838b)
</details>

<details>
<summary> font weight 300 </summary>
</summary>

![image](https://github.com/user-attachments/assets/22ac98be-9804-41d1-a5b7-0fd0991120b6)
</details>

I think 400 looks the best here. It's a small change for now though as mint said he would change the font at some point.